### PR TITLE
Fix listeners

### DIFF
--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -80,7 +80,7 @@ public interface RobotLifecycle {
         @VisibleForTesting
         internal val listeners = mutableSetOf<RobotLifecycle>()
 
-        internal fun rawAddListener(lifecycle: RobotLifecycle) {
+        internal fun add(lifecycle: RobotLifecycle) {
             listeners += lifecycle
         }
 
@@ -89,16 +89,6 @@ public interface RobotLifecycle {
          *
          * @param lifecycle the lifecycle object to receive callbacks
          */
-        public fun addListener(lifecycle: RobotLifecycle) {
-            lifecycle.onCreate()
-            when (state) {
-                Robot.State.TELEOP -> lifecycle.onTeleopStart()
-                Robot.State.AUTO -> lifecycle.onAutoStart()
-                Robot.State.DISABLED -> Unit
-            }
-
-            synchronized(listeners) { listeners += lifecycle }
-        }
 
         /**
          * Removes a listener for [RobotLifecycle] events.
@@ -159,9 +149,9 @@ public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), Ro
 
     init {
         @Suppress("LeakingThis") // Invoked through reflection and initialized later
-        RobotLifecycle.rawAddListener(this)
+        RobotLifecycle.add(this)
 
-        subsystems.forEach { RobotLifecycle.addListener(it) }
+        subsystems.forEach { RobotLifecycle.add(it) }
 
         val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { t, e ->

--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -80,15 +80,14 @@ public interface RobotLifecycle {
         @VisibleForTesting
         internal val listeners = mutableSetOf<RobotLifecycle>()
 
-        internal fun add(lifecycle: RobotLifecycle) {
-            listeners += lifecycle
-        }
-
         /**
          * Adds a listener for [RobotLifecycle] events.
          *
          * @param lifecycle the lifecycle object to receive callbacks
          */
+        private fun add(lifecycle: RobotLifecycle) {
+            listeners += lifecycle
+        }
 
         /**
          * Removes a listener for [RobotLifecycle] events.
@@ -149,9 +148,9 @@ public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), Ro
 
     init {
         @Suppress("LeakingThis") // Invoked through reflection and initialized later
-        RobotLifecycle.add(this)
+        add(this)
 
-        subsystems.forEach { RobotLifecycle.add(it) }
+        subsystems.forEach { add(it) }
 
         val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { t, e ->
@@ -195,3 +194,9 @@ public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), Ro
         DISABLED, AUTO, TELEOP
     }
 }
+
+public fun add(lifecycle: RobotLifecycle) {
+    RobotLifecycle.listeners += lifecycle
+}
+
+public operator fun RobotLifecycle.unaryPlus() = add(this)

--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -5,7 +5,6 @@ package org.sertain
 import android.support.annotation.VisibleForTesting
 import edu.wpi.first.wpilibj.IterativeRobot
 import edu.wpi.first.wpilibj.command.Scheduler
-import org.sertain.command.Subsystem
 
 private typealias LifecycleDistributor = RobotLifecycle.Companion.Distributor
 
@@ -85,8 +84,8 @@ public interface RobotLifecycle {
          *
          * @param lifecycle the lifecycle object to receive callbacks
          */
-        private fun add(lifecycle: RobotLifecycle) {
-            listeners += lifecycle
+        internal fun addListener(lifecycle: RobotLifecycle) {
+            synchronized(listeners) { listeners += lifecycle }
         }
 
         /**
@@ -196,7 +195,13 @@ public abstract class Robot(vararg listeners: RobotLifecycle) : IterativeRobot()
 }
 
 public fun add(lifecycle: RobotLifecycle) {
-    RobotLifecycle.listeners += lifecycle
+    RobotLifecycle.addListener(lifecycle)
 }
 
 public operator fun RobotLifecycle.unaryPlus() = add(this)
+
+public fun remove(lifecycle: RobotLifecycle) {
+    RobotLifecycle.removeListener(lifecycle)
+}
+
+public operator fun RobotLifecycle.unaryMinus() = remove(this)

--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -194,12 +194,18 @@ public abstract class Robot(vararg listeners: RobotLifecycle) : IterativeRobot()
     }
 }
 
+/**
+ * @see RobotLifecycle.addListener
+ */
 public fun add(lifecycle: RobotLifecycle) {
     RobotLifecycle.addListener(lifecycle)
 }
 
 public operator fun RobotLifecycle.unaryPlus() = add(this)
 
+/**
+ * @see RobotLifecycle.removeListener
+ */
 public fun remove(lifecycle: RobotLifecycle) {
     RobotLifecycle.removeListener(lifecycle)
 }

--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -133,7 +133,7 @@ public interface RobotLifecycle {
 }
 
 /** Base robot class which must be used for [RobotLifecycle] callbacks to work. */
-public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), RobotLifecycle {
+public abstract class Robot(vararg listeners: RobotLifecycle) : IterativeRobot(), RobotLifecycle {
     private var mode = State.DISABLED
         set(value) {
             if (value != field) {
@@ -150,7 +150,7 @@ public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), Ro
         @Suppress("LeakingThis") // Invoked through reflection and initialized later
         add(this)
 
-        subsystems.forEach { add(it) }
+        listeners.forEach { add(it) }
 
         val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { t, e ->

--- a/core/src/main/kotlin/org/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sertain/Robot.kt
@@ -5,6 +5,7 @@ package org.sertain
 import android.support.annotation.VisibleForTesting
 import edu.wpi.first.wpilibj.IterativeRobot
 import edu.wpi.first.wpilibj.command.Scheduler
+import org.sertain.command.Subsystem
 
 private typealias LifecycleDistributor = RobotLifecycle.Companion.Distributor
 
@@ -143,7 +144,7 @@ public interface RobotLifecycle {
 }
 
 /** Base robot class which must be used for [RobotLifecycle] callbacks to work. */
-public abstract class Robot : IterativeRobot(), RobotLifecycle {
+public abstract class Robot(vararg subsystems: Subsystem) : IterativeRobot(), RobotLifecycle {
     private var mode = State.DISABLED
         set(value) {
             if (value != field) {
@@ -159,6 +160,8 @@ public abstract class Robot : IterativeRobot(), RobotLifecycle {
     init {
         @Suppress("LeakingThis") // Invoked through reflection and initialized later
         RobotLifecycle.rawAddListener(this)
+
+        subsystems.forEach { RobotLifecycle.addListener(it) }
 
         val existingHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { t, e ->

--- a/core/src/main/kotlin/org/sertain/command/Subsystem.kt
+++ b/core/src/main/kotlin/org/sertain/command/Subsystem.kt
@@ -2,7 +2,6 @@
 @file:JvmName("SubsystemUtils")
 package org.sertain.command
 
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder
 import org.sertain.RobotLifecycle
 import edu.wpi.first.wpilibj.command.Subsystem as WpiLibSubsystem
 
@@ -10,11 +9,6 @@ import edu.wpi.first.wpilibj.command.Subsystem as WpiLibSubsystem
 public abstract class Subsystem : WpiLibSubsystem(), RobotLifecycle {
     /** @see edu.wpi.first.wpilibj.command.Subsystem.setDefaultCommand */
     open val defaultCommand: CommandBase? = null
-
-    override fun initSendable(builder: SendableBuilder?) {
-        super.initSendable(builder)
-        RobotLifecycle.addListener(this)
-    }
 
     override fun initDefaultCommand() = setDefaultCommand(defaultCommand?.mirror)
 }

--- a/core/src/main/kotlin/org/sertain/hardware/Motors.kt
+++ b/core/src/main/kotlin/org/sertain/hardware/Motors.kt
@@ -8,6 +8,7 @@ import com.ctre.phoenix.motorcontrol.NeutralMode
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.wpilibj.PWMSpeedController
 import org.sertain.RobotLifecycle
+import org.sertain.add
 import org.sertain.hardware.BreakWhenStarted.minusAssign
 import org.sertain.hardware.BreakWhenStarted.plusAssign
 import java.util.Timer
@@ -149,7 +150,7 @@ private object BreakWhenStarted : RobotLifecycle {
     private var updateTask: TimerTask? = null
 
     init {
-        RobotLifecycle.addListener(this)
+        add(this)
     }
 
     operator fun BreakWhenStarted.plusAssign(talon: Talon) {

--- a/core/src/test/kotlin/org/sertain/RobotTest.kt
+++ b/core/src/test/kotlin/org/sertain/RobotTest.kt
@@ -12,7 +12,7 @@ class RobotTest {
 
     @Before
     fun beforeEach() {
-        RobotLifecycle.addListener(testLifecycle)
+        RobotLifecycle.add(testLifecycle)
     }
 
     @After

--- a/core/src/test/kotlin/org/sertain/RobotTest.kt
+++ b/core/src/test/kotlin/org/sertain/RobotTest.kt
@@ -12,7 +12,7 @@ class RobotTest {
 
     @Before
     fun beforeEach() {
-        RobotLifecycle.add(testLifecycle)
+        +testLifecycle
     }
 
     @After

--- a/core/src/test/kotlin/org/sertain/RobotTest.kt
+++ b/core/src/test/kotlin/org/sertain/RobotTest.kt
@@ -17,7 +17,7 @@ class RobotTest {
 
     @After
     fun afterEach() {
-        RobotLifecycle.removeListener(testLifecycle)
+        -testLifecycle
     }
 
     @Test


### PR DESCRIPTION
This just fixes some stuff about the listeners. First, it fixes an internal bug which would cause some lifecycle methods to get called at the wrong time. It also adds public api, so now any lifecycle can be added with either `add(lifecycle)` or `+lifecycle`. Lastly, instead of accepting only Subsystems, the Robot class's constructor now accepts all `RobotLifecycle` types. 